### PR TITLE
fix assumption that site uses https

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -44,7 +44,7 @@ exports["default"] = function () {
     reportFixtureStart: function reportFixtureStart(name, path, meta) {
       this.currentFixtureName = name;
       this.currentFixtureMeta = meta;
-      this.slack.addMessage("*Site Tested Against:* <" + this.currentFixtureMeta.siteName + "|" + this.currentFixtureMeta.siteName.match(/https:\/\/(\w+)/)[1] + ">");
+      this.slack.addMessage("*Site Tested Against:* <" + this.currentFixtureMeta.siteName + "|" + this.currentFixtureMeta.siteName.match(/https?:\/\/(\w+)/)[1] + ">");
       this.slack.addMessage("" + (0, _utilsTextFormatters.bold)(this.currentFixtureName));
       // if (loggingLevel === LoggingLevels.TEST)
     },


### PR DESCRIPTION
Currently we assume the site uses `https`, which means we can't use localhost. This fix updates the regex to allow `http`.