### PR TITLE
Add number of failed tests to output

### DIFF
--- a/lib/SlackMessage.js
+++ b/lib/SlackMessage.js
@@ -59,7 +59,7 @@ var SlackMessage = (function () {
     value: function sendTestReport(nrFailedTests) {
       // Sends a summary message of tests failed as a Slack `attachments` object, works but is here for ref only
 
-      this.sendMessage(this.getTestReportMessage()
+      this.sendMessage(this.getTestReportMessage(nrFailedTests)
       // ,nrFailedTests > 0 && this.loggingLevel === loggingLevels.DEBUG
       //   ? {
       //       attachments: [
@@ -74,8 +74,8 @@ var SlackMessage = (function () {
     }
   }, {
     key: "getTestReportMessage",
-    value: function getTestReportMessage() {
-      var message = { text: this.getSlackMessage(), blocks: [] };
+    value: function getTestReportMessage(numberOfFailedTests) {
+      var message = { text: this.getSlackMessage(), blocks: [], numberOfFailedTests: numberOfFailedTests };
       if (this.loggingLevel === _constLoggingLevels2["default"].DEBUG) {
         message.blocks = message.blocks.concat(this.getErrorMessageBlocks());
       }

--- a/src/SlackMessage.js
+++ b/src/SlackMessage.js
@@ -33,7 +33,7 @@ export default class SlackMessage {
     // Sends a summary message of tests failed as a Slack `attachments` object, works but is here for ref only
 
     this.sendMessage(
-      this.getTestReportMessage()
+      this.getTestReportMessage(nrFailedTests)
       // ,nrFailedTests > 0 && this.loggingLevel === loggingLevels.DEBUG
       //   ? {
       //       attachments: [
@@ -47,8 +47,8 @@ export default class SlackMessage {
     );
   }
 
-  getTestReportMessage() {
-    let message = { text: this.getSlackMessage(), blocks: [] };
+  getTestReportMessage(numberOfFailedTests) {
+    let message = { text: this.getSlackMessage(), blocks: [], numberOfFailedTests };
     if (this.loggingLevel === loggingLevels.DEBUG) {
       message.blocks = message.blocks.concat(this.getErrorMessageBlocks());
     }


### PR DESCRIPTION
Adding the number of failed tests to the test results output object. Adding it so that the reporter action can use it to determine if the test run failed, and change the colour of the attachment to red when it failed.

Goes with this PR: https://github.com/thomasnakagawa/action-slacker/pull/1

It'll look like this:
![image](https://user-images.githubusercontent.com/11395364/102672906-065a5980-4147-11eb-8c13-874c872fd44c.png)
